### PR TITLE
retain popped patch order

### DIFF
--- a/git-patch.1.txt
+++ b/git-patch.1.txt
@@ -12,7 +12,7 @@ SYNOPSIS
 [verse]
 *git patch* ['options'] *series* ['commit-ish']
 *git patch* ['options'] *pop* commit-ish
-*git patch* ['options'] *push* commit-ish
+*git patch* ['options'] *push* ['commit-ish']
 *git patch* ['options'] *float* commit-ish
 
 OPTIONS
@@ -53,7 +53,8 @@ COMMANDS
     Removes a commit from the current branch and save it for later retrieval.
 
 *push* ::
-    Re-apply a previously popped patch.
+    Re-apply a previously popped patch, defaulting to last popped patch if no
+    commit-ish is supplied.
 
 *float* ::
     Raise a commit up to the top of the current branch.

--- a/git-patch.1.txt
+++ b/git-patch.1.txt
@@ -11,7 +11,7 @@ SYNOPSIS
 --------
 [verse]
 *git patch* ['options'] *series* ['commit-ish']
-*git patch* ['options'] *pop* commit-ish
+*git patch* ['options'] *pop* ['commit-ish']
 *git patch* ['options'] *push* ['commit-ish']
 *git patch* ['options'] *float* commit-ish
 
@@ -50,7 +50,8 @@ COMMANDS
     have been popped.
 
 *pop* ::
-    Removes a commit from the current branch and save it for later retrieval.
+    Removes a commit from the current branch and save it for later retrieval,
+    defaulting to HEAD if no commit-ish is supplied.
 
 *push* ::
     Re-apply a previously popped patch, defaulting to last popped patch if no

--- a/git-patch.sh
+++ b/git-patch.sh
@@ -18,7 +18,7 @@ SUBDIRECTORY_OK="yes"
 OPTIONS_KEEPDASHDASH=
 OPTIONS_SPEC="\
 git patch [options] series [commit-ish]
-git patch [options] pop commit-ish
+git patch [options] pop [commit-ish]
 git patch [options] push [commit-ish]
 git patch [options] float commit-ish
 git patch [options] delete commit-ish
@@ -102,10 +102,17 @@ do_series()
 
 do_pop()
 {
-	test $# -eq 1 || die "fatal: expected 1 argument."
+	if test $# -eq 0; then
+		rev="HEAD"
+	elif test $# -eq 1; then
+		rev="$1"
+	else
+		die "fatal: expected at most 1 argument."
+	fi
+
 
 	# Verify that we have a valid object
-	sha1="$(git rev-parse --verify $1)" || exit $?
+	sha1="$(git rev-parse --verify $rev)" || exit $?
 
 	# Save the patch
 	name="$(git rev-list --pretty='%f' $sha1 -1 | tail -n1)"
@@ -115,7 +122,7 @@ do_pop()
 	git update-ref "$patchrefs/$name" "$sha1" || die
 
 	# Remove the patch from the current stack
-	git rebase --onto "$1"^ "$1" "$branch"
+	git rebase --onto "$rev"^ "$rev" "$branch"
 }
 
 do_push()

--- a/git-patch.sh
+++ b/git-patch.sh
@@ -95,6 +95,7 @@ do_series()
 
 	git --no-pager log --oneline --decorate "$revs"
 	git --no-pager for-each-ref \
+		--sort=-refname \
 		--format='- %(objectname:short) %(subject) (%(refname))' \
 		"$patchrefs"
 }

--- a/git-patch.sh
+++ b/git-patch.sh
@@ -19,7 +19,7 @@ OPTIONS_KEEPDASHDASH=
 OPTIONS_SPEC="\
 git patch [options] series [commit-ish]
 git patch [options] pop commit-ish
-git patch [options] push commit-ish
+git patch [options] push [commit-ish]
 git patch [options] float commit-ish
 git patch [options] delete commit-ish
 git patch [options] fixup commit-ish [file] [...]
@@ -120,10 +120,16 @@ do_pop()
 
 do_push()
 {
-	test $# -eq 1 || die "fatal: expected 1 argument."
+	if test $# -eq 0; then
+		rev=$(top_ref)
+	elif test $# -eq 1; then
+		rev="$1"
+	else
+		die "fatal: expected at most 1 argument."
+	fi
 
 	# Verify that we have a valid object
-	sha1="$(git rev-parse --verify $1)" || exit $?
+	sha1="$(git rev-parse --verify $rev)" || exit $?
 	# Figure out the ref that we used
 	ref="$(sha1_to_ref $sha1)"
 


### PR DESCRIPTION
Remember the order that patches are popped. Doing so allow intuative pop/push semantics with 0 arguments.
