### PR TITLE
Preserve 'spaces' in arguments

### DIFF
--- a/git-patch.sh
+++ b/git-patch.sh
@@ -251,4 +251,4 @@ case "$1" in
 esac
 
 # Invoke helper function
-do_"${command}" $@
+do_"${command}" "$@"


### PR DESCRIPTION
This will allow users to:
- specify commit-ish with ':/<text>' where 'text' includes spaces
- filenames with spaces